### PR TITLE
remove duplicated method in FeatureService class

### DIFF
--- a/lib/framework/FeaturesService.cpp
+++ b/lib/framework/FeaturesService.cpp
@@ -88,12 +88,3 @@ void FeaturesService::addFeature(String feature, bool enabled)
 
     userFeatures.push_back(newFeature);
 }
-
-void FeaturesService::addFeature(String feature, bool enabled)
-{
-    UserFeature newFeature;
-    newFeature.feature = feature;
-    newFeature.enabled = enabled;
-
-    userFeatures.push_back(newFeature);
-}

--- a/lib/framework/FeaturesService.h
+++ b/lib/framework/FeaturesService.h
@@ -40,8 +40,6 @@ public:
 
     void addFeature(String feature, bool enabled);
 
-    void addFeature(String feature, bool enabled);
-
 private:
     PsychicHttpServer *_server;
     std::vector<UserFeature> userFeatures;


### PR DESCRIPTION
Hi, I'm running into errors compiling the template project, the compiler complains about a duplicated method in the FeatureService class. I just removed the offending lines and everything is back to normal.

The strange thing is that this "typo" seems a bit old and I didn't have issues before the psychichttp update, maybe that's because of the new build flags ? I'm running this on a M1 Mac Studio running MacOS Ventura by the way.