### PR TITLE
Suggestion : add support for esp32-devkit-v1 board

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -93,3 +93,7 @@ board_build.partitions = default_8MB.csv
 board = nodemcu-32s
 board_build.partitions = min_spiffs.csv
 ;build_type = debug
+
+[env:esp32-devkit-v1]
+board = esp32doit-devkit-v1
+board_build.partitions = min_spiffs.csv

--- a/platformio.ini
+++ b/platformio.ini
@@ -89,11 +89,11 @@ board_build.partitions = default_8MB.csv
 ;    -DARDUINO_USB_CDC_ON_BOOT=1
 ;    -DARDUINO_USB_MODE=1
 
-[env:nodemcu-32s]
-board = nodemcu-32s
+[env:esp32dev]
+; Works for nodemcu-32s, devkit-v1 boards and probably others. You can change the pin defines below if needed.
+board = esp32dev
 board_build.partitions = min_spiffs.csv
-;build_type = debug
-
-[env:esp32-devkit-v1]
-board = esp32doit-devkit-v1
-board_build.partitions = min_spiffs.csv
+build_flags =
+    ${env.build_flags}
+    -D LED_BUILTIN=2
+    -D KEY_BUILTIN=0


### PR DESCRIPTION
Hi, although it might not be the best choice to run this project, the "doit" devkit-v1 board and its numerous clones are one of the most common, cheap and available esp32 boards so I thought it might be useful to add it to the template.