### PR TITLE
Pass fetch in load function

### DIFF
--- a/interface/src/routes/+layout.ts
+++ b/interface/src/routes/+layout.ts
@@ -4,7 +4,7 @@ import type { LayoutLoad } from './$types';
 export const prerender = false;
 export const ssr = false;
 
-export const load = (async () => {
+export const load = (async ({ fetch }) => {
 	const result = await fetch('/rest/features');
 	const item = await result.json();
 	return {


### PR DESCRIPTION
# Purpose 
Removes the development warning:
```Loading /rest/features using `window.fetch`. For best results, use the `fetch` that is passed to your `load` function: https://kit.svelte.dev/docs/load#making-fetch-requests```