### PR TITLE
Removes duplicate request

### DIFF
--- a/interface/src/routes/wifi/sta/Wifi.svelte
+++ b/interface/src/routes/wifi/sta/Wifi.svelte
@@ -107,12 +107,6 @@
 
 	onDestroy(() => clearInterval(interval));
 
-	onMount(() => {
-		if (!$page.data.features.security || $user.admin) {
-			getWifiSettings();
-		}
-	});
-
 	async function postWiFiSettings(data: WifiSettings) {
 		try {
 			const response = await fetch('/rest/wifiSettings', {


### PR DESCRIPTION
The component uses the following for loading initial settings:
```svelte
{#await getWifiStatus()}
    <Spinner />
{:then nothing}
```

Which mean the onMount is unnecessary