### PR TITLE
Ensure thread safety for client subscriptions

### DIFF
--- a/lib/framework/EventSocket.cpp
+++ b/lib/framework/EventSocket.cpp
@@ -41,10 +41,12 @@ void EventSocket::onWSOpen(PsychicWebSocketClient *client)
 
 void EventSocket::onWSClose(PsychicWebSocketClient *client)
 {
+    xSemaphoreTake(clientSubscriptionsMutex, portMAX_DELAY);
     for (auto &event_subscriptions : client_subscriptions)
     {
         event_subscriptions.second.remove(client->socket());
     }
+    xSemaphoreGive(clientSubscriptionsMutex);
     ESP_LOGI("EventSocket", "ws[%s][%u] disconnect", client->remoteIP().toString().c_str(), client->socket());
 }
 


### PR DESCRIPTION
The handler `onWSClose`, does not lock the client_subscriptions list, meaning when a client disconnects while an event is emitted from another thread the device crashes due to a race condition.