### PR TITLE
Isolate non-returning functions in new tasks

### DIFF
--- a/lib/framework/RestartService.h
+++ b/lib/framework/RestartService.h
@@ -17,6 +17,7 @@
 
 #include <WiFi.h>
 
+#include <ESPmDNS.h>
 #include <PsychicHttp.h>
 #include <SecurityManager.h>
 
@@ -31,9 +32,16 @@ public:
 
     static void restartNow()
     {
-        WiFi.disconnect(true);
-        delay(500);
-        ESP.restart();
+        xTaskCreate(
+            [](void *pvParams) {
+                delay(250);
+                MDNS.end();
+                delay(100);
+                WiFi.disconnect(true);
+                delay(500);
+                ESP.restart();
+            },
+            "Restart task", 4096, nullptr, 10, nullptr);
     }
 
 private:

--- a/lib/framework/SleepService.cpp
+++ b/lib/framework/SleepService.cpp
@@ -86,9 +86,10 @@ void SleepService::sleepNow()
     Serial.println("Good by!");
 #endif
 
-    // Just to be sure
-    delay(100);
-
-    // Hibernate
-    esp_deep_sleep_start();
+    xTaskCreate(
+        [](void *pvParams) {
+            delay(200);
+            esp_deep_sleep_start();
+        },
+        "Sleep task", 4096, nullptr, 10, nullptr);
 }


### PR DESCRIPTION
# Purpose
When updating firmware, making the device sleep or restarting, the server does not get the chance to respond as the request handling function never returns. 
By wrapping the non-returning functionality in tasks, the server can respond with an OK status before eg. restarting.

```c++
esp_err_t UploadFirmwareService::uploadComplete(PsychicRequest *request)
{
(...)
    if (!request->_tempObject)
    {
        request->reply(200);
        RestartService::restartNow(); 
        return ESP_OK; // Before this could not be reached
    }
}
 ```