### PR TITLE
ESPD_LOGx: replace first argument with TAG and define TAG as 🐼

### DIFF
--- a/lib/framework/APStatus.cpp
+++ b/lib/framework/APStatus.cpp
@@ -28,7 +28,7 @@ void APStatus::begin()
                 _securityManager->wrapRequest(std::bind(&APStatus::apStatus, this, std::placeholders::_1),
                                               AuthenticationPredicates::IS_AUTHENTICATED));
 
-    ESP_LOGV("APStatus", "Registered GET endpoint: %s", AP_STATUS_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered GET endpoint: %s", AP_STATUS_SERVICE_PATH);
 }
 
 esp_err_t APStatus::apStatus(PsychicRequest *request)

--- a/lib/framework/AuthenticationService.cpp
+++ b/lib/framework/AuthenticationService.cpp
@@ -39,7 +39,7 @@ void AuthenticationService::begin()
         }
         return request->reply(401); });
 
-    ESP_LOGV("AuthenticationService", "Registered POST endpoint: %s", SIGN_IN_PATH);
+    ESP_LOGV(TAG, "Registered POST endpoint: %s", SIGN_IN_PATH);
 
     // Verifies that the request supplied a valid JWT
     _server->on(VERIFY_AUTHORIZATION_PATH, HTTP_GET, [this](PsychicRequest *request)
@@ -47,7 +47,7 @@ void AuthenticationService::begin()
         Authentication authentication = _securityManager->authenticateRequest(request);
         return request->reply(authentication.authenticated ? 200 : 401); });
 
-    ESP_LOGV("AuthenticationService", "Registered GET endpoint: %s", VERIFY_AUTHORIZATION_PATH);
+    ESP_LOGV(TAG, "Registered GET endpoint: %s", VERIFY_AUTHORIZATION_PATH);
 }
 
 #endif // end FT_ENABLED(FT_SECURITY)

--- a/lib/framework/DownloadFirmwareService.cpp
+++ b/lib/framework/DownloadFirmwareService.cpp
@@ -37,7 +37,7 @@ void update_progress(int currentBytes, int totalBytes)
         doc["progress"] = progress;
         JsonObject jsonObject = doc.as<JsonObject>();
         _socket->emitEvent(EVENT_DOWNLOAD_OTA, jsonObject);
-        ESP_LOGV("Download OTA", "HTTP update process at %d of %d bytes... (%d %%)", currentBytes, totalBytes, progress);
+        ESP_LOGV(TAG, "HTTP update process at %d of %d bytes... (%d %%)", currentBytes, totalBytes, progress);
     }
     previousProgress = progress;
 }
@@ -85,7 +85,7 @@ void updateTask(void *param)
         jsonObject = doc.as<JsonObject>();
         _socket->emitEvent(EVENT_DOWNLOAD_OTA, jsonObject);
 
-        ESP_LOGE("Download OTA", "HTTP Update failed with error (%d): %s", httpUpdate.getLastError(), httpUpdate.getLastErrorString().c_str());
+        ESP_LOGE(TAG, "HTTP Update failed with error (%d): %s", httpUpdate.getLastError(), httpUpdate.getLastErrorString().c_str());
 #ifdef SERIAL_INFO
         Serial.printf("HTTP Update failed with error (%d): %s\n", httpUpdate.getLastError(), httpUpdate.getLastErrorString().c_str());
 #endif
@@ -97,13 +97,13 @@ void updateTask(void *param)
         jsonObject = doc.as<JsonObject>();
         _socket->emitEvent(EVENT_DOWNLOAD_OTA, jsonObject);
 
-        ESP_LOGE("Download OTA", "HTTP Update failed, has same firmware version");
+        ESP_LOGE(TAG, "HTTP Update failed, has same firmware version");
 #ifdef SERIAL_INFO
         Serial.println("HTTP Update failed, has same firmware version");
 #endif
         break;
     case HTTP_UPDATE_OK:
-        ESP_LOGI("Download OTA", "HTTP Update successful - Restarting");
+        ESP_LOGI(TAG, "HTTP Update successful - Restarting");
 #ifdef SERIAL_INFO
         Serial.println("HTTP Update successful - Restarting");
 #endif
@@ -130,7 +130,7 @@ void DownloadFirmwareService::begin()
                     std::bind(&DownloadFirmwareService::downloadUpdate, this, std::placeholders::_1, std::placeholders::_2),
                     AuthenticationPredicates::IS_ADMIN));
 
-    ESP_LOGV("DownloadFirmwareService", "Registered POST endpoint: %s", GITHUB_FIRMWARE_PATH);
+    ESP_LOGV(TAG, "Registered POST endpoint: %s", GITHUB_FIRMWARE_PATH);
 }
 
 esp_err_t DownloadFirmwareService::downloadUpdate(PsychicRequest *request, JsonVariant &json)
@@ -141,7 +141,7 @@ esp_err_t DownloadFirmwareService::downloadUpdate(PsychicRequest *request, JsonV
     }
 
     String downloadURL = json["download_url"];
-    ESP_LOGI("Download OTA", "Starting OTA from: %s", downloadURL.c_str());
+    ESP_LOGI(TAG, "Starting OTA from: %s", downloadURL.c_str());
 #ifdef SERIAL_INFO
     Serial.println("Starting OTA from: " + downloadURL);
 #endif
@@ -163,7 +163,7 @@ esp_err_t DownloadFirmwareService::downloadUpdate(PsychicRequest *request, JsonV
             1                           // Have it on application core
             ) != pdPASS)
     {
-        ESP_LOGE("Download OTA", "Couldn't create download OTA task");
+        ESP_LOGE(TAG, "Couldn't create download OTA task");
         return request->reply(500);
     }
     return request->reply(200);

--- a/lib/framework/ESP32SvelteKit.cpp
+++ b/lib/framework/ESP32SvelteKit.cpp
@@ -59,7 +59,7 @@ ESP32SvelteKit::ESP32SvelteKit(PsychicHttpServer *server, unsigned int numberEnd
 
 void ESP32SvelteKit::begin()
 {
-    ESP_LOGV("ESP32SvelteKit", "Loading settings from files system");
+    ESP_LOGV(TAG, "Loading settings from files system");
     ESPFS.begin(true);
 
     _wifiSettingsService.initWiFi();
@@ -71,7 +71,7 @@ void ESP32SvelteKit::begin()
 
 #ifdef EMBED_WWW
     // Serve static resources from PROGMEM
-    ESP_LOGV("ESP32SvelteKit", "Registering routes from PROGMEM static resources");
+    ESP_LOGV(TAG, "Registering routes from PROGMEM static resources");
     WWWData::registerRoutes(
         [&](const String &uri, const String &contentType, const uint8_t *content, size_t len)
         {
@@ -98,7 +98,7 @@ void ESP32SvelteKit::begin()
         });
 #else
     // Serve static resources from /www/
-    ESP_LOGV("ESP32SvelteKit", "Registering routes from FS /www/ static resources");
+    ESP_LOGV(TAG, "Registering routes from FS /www/ static resources");
     _server->serveStatic("/_app/", ESPFS, "/www/_app/");
     _server->serveStatic("/favicon.png", ESPFS, "/www/favicon.png");
     //  Serving all other get requests with "/www/index.htm"
@@ -118,13 +118,13 @@ void ESP32SvelteKit::begin()
 #endif
 
 #if defined(ENABLE_CORS)
-    ESP_LOGV("ESP32SvelteKit", "Enabling CORS headers");
+    ESP_LOGV(TAG, "Enabling CORS headers");
     DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", CORS_ORIGIN);
     DefaultHeaders::Instance().addHeader("Access-Control-Allow-Headers", "Accept, Content-Type, Authorization");
     DefaultHeaders::Instance().addHeader("Access-Control-Allow-Credentials", "true");
 #endif
 
-    ESP_LOGV("ESP32SvelteKit", "Starting MDNS");
+    ESP_LOGV(TAG, "Starting MDNS");
     MDNS.begin(_wifiSettingsService.getHostname().c_str());
     MDNS.setInstanceName(_appName);
     MDNS.addService("http", "tcp", 80);
@@ -177,7 +177,7 @@ void ESP32SvelteKit::begin()
 #endif
 
     // Start the loop task
-    ESP_LOGV("ESP32SvelteKit", "Starting loop task");
+    ESP_LOGV(TAG, "Starting loop task");
     xTaskCreatePinnedToCore(
         this->_loopImpl,            // Function that should be called
         "ESP32 SvelteKit Loop",     // Name of the task (for debugging)

--- a/lib/framework/FactoryResetService.cpp
+++ b/lib/framework/FactoryResetService.cpp
@@ -30,7 +30,7 @@ void FactoryResetService::begin()
                 HTTP_POST,
                 _securityManager->wrapRequest(std::bind(&FactoryResetService::handleRequest, this, _1), AuthenticationPredicates::IS_ADMIN));
 
-    ESP_LOGV("FactoryResetService", "Registered POST endpoint: %s", FACTORY_RESET_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered POST endpoint: %s", FACTORY_RESET_SERVICE_PATH);
 }
 
 esp_err_t FactoryResetService::handleRequest(PsychicRequest *request)

--- a/lib/framework/FeaturesService.cpp
+++ b/lib/framework/FeaturesService.cpp
@@ -27,13 +27,13 @@ void FeaturesService::begin()
                     createJSON(root);
                     return response.send(); });
 
-    ESP_LOGV("FeaturesService", "Registered GET endpoint: %s", FEATURES_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered GET endpoint: %s", FEATURES_SERVICE_PATH);
 
     _socket->registerEvent(FEATURES_SERVICE_EVENT);
 
     _socket->onSubscribe(FEATURES_SERVICE_EVENT, [&](const String &originId)
                          {
-                             ESP_LOGV("FeaturesService", "Sending features to %s", originId.c_str());
+                             ESP_LOGV(TAG, "Sending features to %s", originId.c_str());
                              JsonDocument doc;
                              JsonObject root = doc.as<JsonObject>();
                              createJSON(root);

--- a/lib/framework/HttpEndpoint.h
+++ b/lib/framework/HttpEndpoint.h
@@ -70,7 +70,7 @@ public:
                             return response.send();
                         },
                         _authenticationPredicate));
-        ESP_LOGV("HttpEndpoint", "Registered GET endpoint: %s", _servicePath);
+        ESP_LOGV(TAG, "Registered GET endpoint: %s", _servicePath);
 
         // POST
         _server->on(_servicePath,
@@ -105,7 +105,7 @@ public:
                         },
                         _authenticationPredicate));
 
-        ESP_LOGV("HttpEndpoint", "Registered POST endpoint: %s", _servicePath);
+        ESP_LOGV(TAG, "Registered POST endpoint: %s", _servicePath);
     }
 };
 

--- a/lib/framework/MqttSettingsService.cpp
+++ b/lib/framework/MqttSettingsService.cpp
@@ -125,7 +125,7 @@ void MqttSettingsService::onMqttConnect(bool sessionPresent)
     String uri = _mqttClient.getMqttConfig()->uri;
 #endif
 
-    ESP_LOGI("MQTT", "Connected to MQTT: %s", uri.c_str());
+    ESP_LOGI(TAG, "Connected to MQTT: %s", uri.c_str());
 #ifdef SERIAL_INFO
     Serial.printf("Connected to MQTT: %s\n", uri.c_str());
 #endif
@@ -134,7 +134,7 @@ void MqttSettingsService::onMqttConnect(bool sessionPresent)
 
 void MqttSettingsService::onMqttDisconnect(bool sessionPresent)
 {
-    ESP_LOGI("MQTT", "Disconnected from MQTT.");
+    ESP_LOGI(TAG, "Disconnected from MQTT.");
 #ifdef SERIAL_INFO
     Serial.println("Disconnected from MQTT.");
 #endif
@@ -145,7 +145,7 @@ void MqttSettingsService::onMqttError(esp_mqtt_error_codes_t error)
     if (error.error_type == MQTT_ERROR_TYPE_TCP_TRANSPORT)
     {
         _lastError = strerror(error.esp_transport_sock_errno);
-        ESP_LOGE("MQTT", "MQTT TCP error: %s", _lastError.c_str());
+        ESP_LOGE(TAG, "MQTT TCP error: %s", _lastError.c_str());
     }
 }
 
@@ -158,7 +158,7 @@ void MqttSettingsService::onStationModeGotIP(WiFiEvent_t event, WiFiEventInfo_t 
 {
     if (_state.enabled)
     {
-        ESP_LOGI("MQTT", "WiFi connection established, starting MQTT client.");
+        ESP_LOGI(TAG, "WiFi connection established, starting MQTT client.");
         onConfigUpdated();
     }
 }
@@ -167,7 +167,7 @@ void MqttSettingsService::onStationModeDisconnected(WiFiEvent_t event, WiFiEvent
 {
     if (_state.enabled)
     {
-        ESP_LOGI("MQTT", "WiFi connection dropped, stopping MQTT client.");
+        ESP_LOGI(TAG, "WiFi connection dropped, stopping MQTT client.");
         onConfigUpdated();
     }
 }

--- a/lib/framework/MqttStatus.cpp
+++ b/lib/framework/MqttStatus.cpp
@@ -29,7 +29,7 @@ void MqttStatus::begin()
                 _securityManager->wrapRequest(std::bind(&MqttStatus::mqttStatus, this, std::placeholders::_1),
                                               AuthenticationPredicates::IS_AUTHENTICATED));
 
-    ESP_LOGV("MqttStatus", "Registered GET endpoint: %s", MQTT_STATUS_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered GET endpoint: %s", MQTT_STATUS_SERVICE_PATH);
 }
 
 esp_err_t MqttStatus::mqttStatus(PsychicRequest *request)

--- a/lib/framework/NTPSettingsService.cpp
+++ b/lib/framework/NTPSettingsService.cpp
@@ -41,7 +41,7 @@ void NTPSettingsService::begin()
                     std::bind(&NTPSettingsService::configureTime, this, std::placeholders::_1, std::placeholders::_2),
                     AuthenticationPredicates::IS_ADMIN));
 
-    ESP_LOGV("NTPSettingsService", "Registered POST endpoint: %s", TIME_PATH);
+    ESP_LOGV(TAG, "Registered POST endpoint: %s", TIME_PATH);
 
     _fsPersistence.readFromFS();
     configureNTP();

--- a/lib/framework/NTPStatus.cpp
+++ b/lib/framework/NTPStatus.cpp
@@ -26,7 +26,7 @@ void NTPStatus::begin()
                 _securityManager->wrapRequest(std::bind(&NTPStatus::ntpStatus, this, std::placeholders::_1),
                                               AuthenticationPredicates::IS_AUTHENTICATED));
 
-    ESP_LOGV("NTPStatus", "Registered GET endpoint: %s", NTP_STATUS_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered GET endpoint: %s", NTP_STATUS_SERVICE_PATH);
 }
 
 /*

--- a/lib/framework/RestartService.cpp
+++ b/lib/framework/RestartService.cpp
@@ -26,7 +26,7 @@ void RestartService::begin()
                 _securityManager->wrapRequest(std::bind(&RestartService::restart, this, std::placeholders::_1),
                                               AuthenticationPredicates::IS_ADMIN));
 
-    ESP_LOGV("RestartService", "Registered POST endpoint: %s", RESTART_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered POST endpoint: %s", RESTART_SERVICE_PATH);
 }
 
 esp_err_t RestartService::restart(PsychicRequest *request)

--- a/lib/framework/SecurityManager.h
+++ b/lib/framework/SecurityManager.h
@@ -26,6 +26,9 @@
 #define AUTHORIZATION_HEADER_PREFIX "Bearer "
 #define AUTHORIZATION_HEADER_PREFIX_LEN 7
 
+#undef TAG
+#define TAG "🐼"
+
 class User
 {
 public:

--- a/lib/framework/SecuritySettingsService.cpp
+++ b/lib/framework/SecuritySettingsService.cpp
@@ -33,7 +33,7 @@ void SecuritySettingsService::begin()
                 wrapRequest(std::bind(&SecuritySettingsService::generateToken, this, std::placeholders::_1),
                             AuthenticationPredicates::IS_ADMIN));
 
-    ESP_LOGV("SecuritySettingsService", "Registered GET endpoint: %s", GENERATE_TOKEN_PATH);
+    ESP_LOGV(TAG, "Registered GET endpoint: %s", GENERATE_TOKEN_PATH);
 
     _httpEndpoint.begin();
     _fsPersistence.readFromFS();
@@ -46,7 +46,7 @@ Authentication SecuritySettingsService::authenticateRequest(PsychicRequest *requ
     if (request->hasHeader(AUTHORIZATION_HEADER))
     {
         auto value = request->header(AUTHORIZATION_HEADER);
-        // ESP_LOGV("SecuritySettingsService", "Authorization header: %s", value.c_str());
+        // ESP_LOGV(TAG, "Authorization header: %s", value.c_str());
         if (value.startsWith(AUTHORIZATION_HEADER_PREFIX))
         {
             value = value.substring(AUTHORIZATION_HEADER_PREFIX_LEN);
@@ -56,7 +56,7 @@ Authentication SecuritySettingsService::authenticateRequest(PsychicRequest *requ
     else if (request->hasParam(ACCESS_TOKEN_PARAMATER))
     {
         String value = request->getParam(ACCESS_TOKEN_PARAMATER)->value();
-        // ESP_LOGV("SecuritySettingsService", "Access token parameter: %s", value.c_str());
+        // ESP_LOGV(TAG, "Access token parameter: %s", value.c_str());
         return authenticateJWT(value);
     }
     return Authentication();
@@ -124,8 +124,8 @@ PsychicRequestFilterFunction SecuritySettingsService::filterRequest(Authenticati
 {
     return [this, predicate](PsychicRequest *request)
     {
-        // ESP_LOGV("SecuritySettingsService", "Authenticating filter request: %s", request->uri().c_str());
-        // ESP_LOGV("SecuritySettingsService", "Request Method: %s", request->methodStr().c_str());
+        // ESP_LOGV(TAG, "Authenticating filter request: %s", request->uri().c_str());
+        // ESP_LOGV(TAG, "Request Method: %s", request->methodStr().c_str());
 
         // TODO: This is a hack to allow bogus websocket filter requests to pass through
         // This is a temporary fix until the PsychicHttp websocket handler is fixed to not send a bogus filter request
@@ -133,7 +133,7 @@ PsychicRequestFilterFunction SecuritySettingsService::filterRequest(Authenticati
         // Check if we have a bogus filter request and return true
         if (request->uri().isEmpty() && request->method() == HTTP_DELETE)
         {
-            // ESP_LOGV("SecuritySettingsService", "Bogus filter request - allowing");
+            // ESP_LOGV(TAG, "Bogus filter request - allowing");
             return true;
         }
         else
@@ -141,7 +141,7 @@ PsychicRequestFilterFunction SecuritySettingsService::filterRequest(Authenticati
 
         Authentication authentication = authenticateRequest(request);
         bool result = predicate(authentication);
-        // ESP_LOGV("SecuritySettingsService", "Filter Request %s", result ? "allowed" : "denied");
+        // ESP_LOGV(TAG, "Filter Request %s", result ? "allowed" : "denied");
         return result;
     };
 }
@@ -203,7 +203,7 @@ PsychicRequestFilterFunction SecuritySettingsService::filterRequest(Authenticati
 {
     return [this, predicate](PsychicRequest *request)
     {
-        // ESP_LOGV("SecuritySettingsService", "Security disabled - all requests are allowed");
+        // ESP_LOGV(TAG, "Security disabled - all requests are allowed");
         return true;
     };
 }

--- a/lib/framework/SleepService.cpp
+++ b/lib/framework/SleepService.cpp
@@ -44,7 +44,7 @@ void SleepService::begin()
                 _securityManager->wrapRequest(std::bind(&SleepService::sleep, this, std::placeholders::_1),
                                               AuthenticationPredicates::IS_AUTHENTICATED));
 
-    ESP_LOGV("SleepService", "Registered POST endpoint: %s", SLEEP_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered POST endpoint: %s", SLEEP_SERVICE_PATH);
 }
 
 esp_err_t SleepService::sleep(PsychicRequest *request)
@@ -60,7 +60,7 @@ void SleepService::sleepNow()
 #ifdef SERIAL_INFO
     Serial.println("Going into deep sleep now");
 #endif
-    ESP_LOGI("SleepService", "Going into deep sleep now");
+    ESP_LOGI(TAG, "Going into deep sleep now");
     // Callback for main code sleep preparation
     if (_callbackSleep != nullptr)
     {
@@ -74,7 +74,7 @@ void SleepService::sleepNow()
     WiFi.disconnect(true);
     delay(500);
 
-    ESP_LOGD("SleepService", "Enabling GPIO wakeup on pin GPIO%d\n", _wakeUpPin);
+    ESP_LOGD(TAG, "Enabling GPIO wakeup on pin GPIO%d\n", _wakeUpPin);
 
 // special treatment for ESP32-C3 because of the RISC-V architecture
 #ifdef CONFIG_IDF_TARGET_ESP32C3

--- a/lib/framework/SystemStatus.cpp
+++ b/lib/framework/SystemStatus.cpp
@@ -109,7 +109,7 @@ void SystemStatus::begin()
                 _securityManager->wrapRequest(std::bind(&SystemStatus::systemStatus, this, std::placeholders::_1),
                                               AuthenticationPredicates::IS_AUTHENTICATED));
 
-    ESP_LOGV("SystemStatus", "Registered GET endpoint: %s", SYSTEM_STATUS_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered GET endpoint: %s", SYSTEM_STATUS_SERVICE_PATH);
 }
 
 esp_err_t SystemStatus::systemStatus(PsychicRequest *request)

--- a/lib/framework/UploadFirmwareService.cpp
+++ b/lib/framework/UploadFirmwareService.cpp
@@ -39,7 +39,7 @@ void UploadFirmwareService::begin()
     uploadHandler->onClose(std::bind(&UploadFirmwareService::handleEarlyDisconnect, this)); // gets called if client disconnects
     _server->on(UPLOAD_FIRMWARE_PATH, HTTP_POST, uploadHandler);
 
-    ESP_LOGV("UploadFirmwareService", "Registered POST endpoint: %s", UPLOAD_FIRMWARE_PATH);
+    ESP_LOGV(TAG, "Registered POST endpoint: %s", UPLOAD_FIRMWARE_PATH);
 }
 
 esp_err_t UploadFirmwareService::handleUpload(PsychicRequest *request,

--- a/lib/framework/WebSocketServer.h
+++ b/lib/framework/WebSocketServer.h
@@ -61,7 +61,7 @@ public:
                                      std::placeholders::_2));
         _server->on(_webSocketPath.c_str(), &_webSocket);
 
-        ESP_LOGV("WebSocketServer", "Registered WebSocket handler: %s", _webSocketPath.c_str());
+        ESP_LOGV(TAG, "Registered WebSocket handler: %s", _webSocketPath.c_str());
     }
 
     void onWSOpen(PsychicWebSocketClient *client)
@@ -70,21 +70,21 @@ public:
         // when a client connects, we transmit it's id and the current payload
         transmitId(client);
         transmitData(client, WEB_SOCKET_ORIGIN);
-        ESP_LOGI("WebSocketServer", "ws[%s][%u] connect", client->remoteIP().toString().c_str(), client->socket());
+        ESP_LOGI(TAG, "ws[%s][%u] connect", client->remoteIP().toString().c_str(), client->socket());
     }
 
     void onWSClose(PsychicWebSocketClient *client)
     {
-        ESP_LOGI("WebSocketServer", "ws[%s][%u] disconnect", client->remoteIP().toString().c_str(), client->socket());
+        ESP_LOGI(TAG, "ws[%s][%u] disconnect", client->remoteIP().toString().c_str(), client->socket());
     }
 
     esp_err_t onWSFrame(PsychicWebSocketRequest *request, httpd_ws_frame *frame)
     {
-        ESP_LOGV("WebSocketServer", "ws[%s][%u] opcode[%d]", request->client()->remoteIP().toString().c_str(), request->client()->socket(), frame->type);
+        ESP_LOGV(TAG, "ws[%s][%u] opcode[%d]", request->client()->remoteIP().toString().c_str(), request->client()->socket(), frame->type);
 
         if (frame->type == HTTPD_WS_TYPE_TEXT)
         {
-            ESP_LOGV("WebSocketServer", "ws[%s][%u] request: %s", request->client()->remoteIP().toString().c_str(), request->client()->socket(), (char *)frame->payload);
+            ESP_LOGV(TAG, "ws[%s][%u] request: %s", request->client()->remoteIP().toString().c_str(), request->client()->socket(), (char *)frame->payload);
 
             JsonDocument jsonDocument;
             DeserializationError error = deserializeJson(jsonDocument, (char *)frame->payload, frame->len);

--- a/lib/framework/WiFiScanner.cpp
+++ b/lib/framework/WiFiScanner.cpp
@@ -27,14 +27,14 @@ void WiFiScanner::begin()
                 _securityManager->wrapRequest(std::bind(&WiFiScanner::scanNetworks, this, std::placeholders::_1),
                                               AuthenticationPredicates::IS_ADMIN));
 
-    ESP_LOGV("WiFiScanner", "Registered GET endpoint: %s", SCAN_NETWORKS_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered GET endpoint: %s", SCAN_NETWORKS_SERVICE_PATH);
 
     _server->on(LIST_NETWORKS_SERVICE_PATH,
                 HTTP_GET,
                 _securityManager->wrapRequest(std::bind(&WiFiScanner::listNetworks, this, std::placeholders::_1),
                                               AuthenticationPredicates::IS_ADMIN));
 
-    ESP_LOGV("WiFiScanner", "Registered GET endpoint: %s", LIST_NETWORKS_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered GET endpoint: %s", LIST_NETWORKS_SERVICE_PATH);
 }
 
 esp_err_t WiFiScanner::scanNetworks(PsychicRequest *request)

--- a/lib/framework/WiFiSettingsService.cpp
+++ b/lib/framework/WiFiSettingsService.cpp
@@ -77,7 +77,7 @@ void WiFiSettingsService::reconfigureWiFiConnection()
         break;
     }
 
-    ESP_LOGI("WiFiSettingsService", "Reconfiguring WiFi connection to: %s", connectionMode.c_str());
+    ESP_LOGI(TAG, "Reconfiguring WiFi connection to: %s", connectionMode.c_str());
 
     // disconnect and de-configure wifi
     if (WiFi.disconnect(true))
@@ -137,15 +137,15 @@ void WiFiSettingsService::connectToWiFi()
     int scanResult = WiFi.scanNetworks();
     if (scanResult == WIFI_SCAN_FAILED)
     {
-        ESP_LOGE("WiFiSettingsService", "WiFi scan failed.");
+        ESP_LOGE(TAG, "WiFi scan failed.");
     }
     else if (scanResult == 0)
     {
-        ESP_LOGW("WiFiSettingsService", "No networks found.");
+        ESP_LOGW(TAG, "No networks found.");
     }
     else
     {
-        ESP_LOGI("WiFiSettingsService", "%d networks found.", scanResult);
+        ESP_LOGI(TAG, "%d networks found.", scanResult);
 
         // find the best network to connect
         wifi_settings_t *bestNetwork = NULL;
@@ -160,7 +160,7 @@ void WiFiSettingsService::connectToWiFi()
             int32_t chan_scan;
 
             WiFi.getNetworkInfo(i, ssid_scan, sec_scan, rssi_scan, BSSID_scan, chan_scan);
-            ESP_LOGV("WiFiSettingsService", "SSID: %s, BSSID: " MACSTR ", RSSI: %d dbm, Channel: %d", ssid_scan.c_str(), MAC2STR(BSSID_scan), rssi_scan, chan_scan);
+            ESP_LOGV(TAG, "SSID: %s, BSSID: " MACSTR ", RSSI: %d dbm, Channel: %d", ssid_scan.c_str(), MAC2STR(BSSID_scan), rssi_scan, chan_scan);
 
             for (auto &network : _state.wifiSettings)
             {
@@ -169,7 +169,7 @@ void WiFiSettingsService::connectToWiFi()
                     if (rssi_scan > bestNetworkDb)
                     { // best network
                         bestNetworkDb = rssi_scan;
-                        ESP_LOGV("WiFiSettingsService", "--> New best network SSID: %s, BSSID: " MACSTR "", ssid_scan.c_str(), MAC2STR(BSSID_scan));
+                        ESP_LOGV(TAG, "--> New best network SSID: %s, BSSID: " MACSTR "", ssid_scan.c_str(), MAC2STR(BSSID_scan));
                         network.available = true;
                         network.channel = chan_scan;
                         memcpy(network.bssid, BSSID_scan, 6);
@@ -194,7 +194,7 @@ void WiFiSettingsService::connectToWiFi()
             {
                 if (network.available == true)
                 {
-                    ESP_LOGI("WiFiSettingsService", "Connecting to first available network: %s", network.ssid.c_str());
+                    ESP_LOGI(TAG, "Connecting to first available network: %s", network.ssid.c_str());
                     configureNetwork(network);
                     break;
                 }
@@ -202,12 +202,12 @@ void WiFiSettingsService::connectToWiFi()
         }
         else if (_state.staConnectionMode == (u_int8_t)STAConnectionMode::STRENGTH && bestNetwork)
         {
-            ESP_LOGI("WiFiSettingsService", "Connecting to strongest network: %s, BSSID: " MACSTR " ", bestNetwork->ssid.c_str(), MAC2STR(bestNetwork->bssid));
+            ESP_LOGI(TAG, "Connecting to strongest network: %s, BSSID: " MACSTR " ", bestNetwork->ssid.c_str(), MAC2STR(bestNetwork->bssid));
             configureNetwork(*bestNetwork);
         }
         else // no suitable network to connect
         {
-            ESP_LOGI("WiFiSettingsService", "No known networks found.");
+            ESP_LOGI(TAG, "No known networks found.");
         }
 
         // delete scan results

--- a/lib/framework/WiFiSettingsService.h
+++ b/lib/framework/WiFiSettingsService.h
@@ -109,7 +109,7 @@ public:
             JsonUtils::writeIP(root, "dns_ip_2", wifi.dnsIP2);
         }
 
-        ESP_LOGV("WiFiSettings", "WiFi Settings read");
+        ESP_LOGV(TAG, "WiFi Settings read");
     }
 
     static StateUpdateResult update(JsonObject &root, WiFiSettings &settings)
@@ -130,7 +130,7 @@ public:
                 // max 5 wifi networks
                 if (i++ >= 5)
                 {
-                    ESP_LOGE("WiFiSettings", "Too many wifi networks");
+                    ESP_LOGE(TAG, "Too many wifi networks");
                     break;
                 }
 
@@ -140,7 +140,7 @@ public:
                 // Check if SSID length is between 1 and 31 characters and password between 0 and 64 characters
                 if (wifi["ssid"].as<String>().length() < 1 || wifi["ssid"].as<String>().length() > 31 || wifi["password"].as<String>().length() > 64)
                 {
-                    ESP_LOGE("WiFiSettings", "SSID or password length is invalid");
+                    ESP_LOGE(TAG, "SSID or password length is invalid");
                 }
                 else
                 {
@@ -201,7 +201,7 @@ public:
                 });
             }
         }
-        ESP_LOGV("WiFiSettings", "WiFi Settings updated");
+        ESP_LOGV(TAG, "WiFi Settings updated");
 
         return StateUpdateResult::CHANGED;
     };

--- a/lib/framework/WiFiStatus.cpp
+++ b/lib/framework/WiFiStatus.cpp
@@ -27,7 +27,7 @@ void WiFiStatus::begin()
                 _securityManager->wrapRequest(std::bind(&WiFiStatus::wifiStatus, this, std::placeholders::_1),
                                               AuthenticationPredicates::IS_AUTHENTICATED));
 
-    ESP_LOGV("WiFiStatus", "Registered GET endpoint: %s", WIFI_STATUS_SERVICE_PATH);
+    ESP_LOGV(TAG, "Registered GET endpoint: %s", WIFI_STATUS_SERVICE_PATH);
 
     WiFi.onEvent(onStationModeConnected, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_CONNECTED);
     WiFi.onEvent(onStationModeDisconnected, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
@@ -36,7 +36,7 @@ void WiFiStatus::begin()
 
 void WiFiStatus::onStationModeConnected(WiFiEvent_t event, WiFiEventInfo_t info)
 {
-    ESP_LOGI("WiFiStatus", "WiFi Connected.");
+    ESP_LOGI(TAG, "WiFi Connected.");
 
 #ifdef SERIAL_INFO
     Serial.println("WiFi Connected.");
@@ -45,7 +45,7 @@ void WiFiStatus::onStationModeConnected(WiFiEvent_t event, WiFiEventInfo_t info)
 
 void WiFiStatus::onStationModeDisconnected(WiFiEvent_t event, WiFiEventInfo_t info)
 {
-    ESP_LOGI("WiFiStatus", "WiFi Disconnected. Reason code=%d", info.wifi_sta_disconnected.reason);
+    ESP_LOGI(TAG, "WiFi Disconnected. Reason code=%d", info.wifi_sta_disconnected.reason);
 
 #ifdef SERIAL_INFO
     Serial.print("WiFi Disconnected. Reason code=");
@@ -55,7 +55,7 @@ void WiFiStatus::onStationModeDisconnected(WiFiEvent_t event, WiFiEventInfo_t in
 
 void WiFiStatus::onStationModeGotIP(WiFiEvent_t event, WiFiEventInfo_t info)
 {
-    ESP_LOGI("WiFiStatus", "WiFi Got IP. localIP=%s, hostName=%s", WiFi.localIP().toString().c_str(), WiFi.getHostname());
+    ESP_LOGI(TAG, "WiFi Got IP. localIP=%s, hostName=%s", WiFi.localIP().toString().c_str(), WiFi.getHostname());
 #ifdef SERIAL_INFO
     Serial.printf("WiFi Got IP. localIP=%s, hostName=%s\r\n", WiFi.localIP().toString().c_str(), WiFi.getHostname());
 #endif


### PR DESCRIPTION
This has a few advantages:
- First argument is already displayed in the output so no need to repeat, makes the text more compact
- Easy to visually see which log comes from which part of the system.  🐼 is core ESP32-sveltekit, other tags can be used for added functionality
- Funny 😉