### PR TITLE
Add /rest/coreDump endpoint

### DIFF
--- a/lib/framework/CoreDump.cpp
+++ b/lib/framework/CoreDump.cpp
@@ -1,0 +1,89 @@
+/**
+ *   ESP32 SvelteKit
+ *
+ *   A simple, secure and extensible framework for IoT projects for ESP32 platforms
+ *   with responsive Sveltekit front-end built with TailwindCSS and DaisyUI.
+ *   https://github.com/theelims/ESP32-sveltekit
+ *
+ *   Copyright (C) 2018 - 2023 rjwats
+ *   Copyright (C) 2023 - 2024 theelims
+ *
+ *   All Rights Reserved. This software may be modified and distributed under
+ *   the terms of the LGPL v3 license. See the LICENSE file for details.
+ **/
+
+#include <CoreDump.h>
+#include <esp32-hal.h>
+
+#include "esp_core_dump.h"
+#include "esp_partition.h"
+
+static const char *TAG = "CoreDump";
+#define MIN(a, b) ({ __typeof__ (a) _a = (a); __typeof__ (b) _b = (b); _a < _b ? _a : _b; })
+
+CoreDump::CoreDump(PsychicHttpServer *server,
+                   SecurityManager *securityManager) : _server(server),
+                                                       _securityManager(securityManager) {
+}
+
+void CoreDump::begin() {
+    _server->on(CORE_DUMP_SERVICE_PATH,
+                HTTP_GET,
+                _securityManager->wrapRequest(std::bind(&CoreDump::coreDump, this, std::placeholders::_1),
+                                              AuthenticationPredicates::IS_AUTHENTICATED));
+
+    ESP_LOGV("CoreDump", "Registered GET endpoint: %s", CORE_DUMP_SERVICE_PATH);
+}
+
+esp_err_t CoreDump::coreDump(PsychicRequest *request) {
+    size_t coredump_addr;
+    size_t coredump_size;
+    esp_err_t err = esp_core_dump_image_get(&coredump_addr, &coredump_size);
+    if (err != ESP_OK) {
+        request->reply(500, "application/json", "{\"status\":\"error\",\"message\":\"core dump not available\"}");
+        return err;
+    }
+    size_t const chunk_len = 3 * 16;  // must be multiple of 3
+    size_t const b64_len = chunk_len / 3 * 4 + 4;
+    uint8_t *const chunk = (uint8_t *)malloc(chunk_len);
+    char *const b64 = (char *)malloc(b64_len);
+    assert(chunk && b64);
+
+    /*if (write_cfg->start) {
+        if ((err = write_cfg->start(write_cfg->priv)) != ESP_OK) {
+            return err;
+        }
+    }*/
+
+    ESP_LOGI(TAG, "Coredump is %u bytes", coredump_size);
+    httpd_resp_set_status(request->request(), "200 OK");
+    PsychicResponse response(request);
+    response.setCode(200);
+    response.setContentType("text/plain");
+    response.sendHeaders();
+    for (size_t offset = 0; offset < coredump_size; offset += chunk_len) {
+        uint const read_len = MIN(chunk_len, coredump_size - offset);
+        if (esp_flash_read(esp_flash_default_chip, chunk, coredump_addr + offset, read_len)) {
+            ESP_LOGE(TAG, "Coredump read failed");
+            break;
+        }
+        err = response.sendChunk(chunk, read_len);
+        if (err != ESP_OK) {
+            break;
+        }
+    }
+    free(chunk);
+    free(b64);
+
+    err = response.finishChunking();
+
+    /*uint32_t sec_num = coredump_size / SPI_FLASH_SEC_SIZE;
+    if (coredump_size % SPI_FLASH_SEC_SIZE) {
+        sec_num++;
+    }
+    err = esp_flash_erase_region(esp_flash_default_chip, coredump_addr, sec_num * SPI_FLASH_SEC_SIZE);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to erase coredump (%d)!", err);
+    }*/
+    return err;
+}

--- a/lib/framework/CoreDump.h
+++ b/lib/framework/CoreDump.h
@@ -1,0 +1,38 @@
+#ifndef CoreDump_h
+#define CoreDump_h
+
+/**
+ *   ESP32 SvelteKit
+ *
+ *   A simple, secure and extensible framework for IoT projects for ESP32 platforms
+ *   with responsive Sveltekit front-end built with TailwindCSS and DaisyUI.
+ *   https://github.com/theelims/ESP32-sveltekit
+ *
+ *   Copyright (C) 2018 - 2023 rjwats
+ *   Copyright (C) 2023 - 2024 theelims
+ *
+ *   All Rights Reserved. This software may be modified and distributed under
+ *   the terms of the LGPL v3 license. See the LICENSE file for details.
+ **/
+
+#include <ArduinoJson.h>
+#include <ESPFS.h>
+#include <PsychicHttp.h>
+#include <SecurityManager.h>
+#include <WiFi.h>
+
+#define CORE_DUMP_SERVICE_PATH "/rest/coreDump"
+
+class CoreDump {
+   public:
+    CoreDump(PsychicHttpServer *server, SecurityManager *securityManager);
+
+    void begin();
+
+   private:
+    PsychicHttpServer *_server;
+    SecurityManager *_securityManager;
+    esp_err_t coreDump(PsychicRequest *request);
+};
+
+#endif  // end CoreDump_h

--- a/lib/framework/ESP32SvelteKit.cpp
+++ b/lib/framework/ESP32SvelteKit.cpp
@@ -53,7 +53,8 @@ ESP32SvelteKit::ESP32SvelteKit(PsychicHttpServer *server, unsigned int numberEnd
 #endif
                                                                                           _restartService(server, &_securitySettingsService),
                                                                                           _factoryResetService(server, &ESPFS, &_securitySettingsService),
-                                                                                          _systemStatus(server, &_securitySettingsService)
+                                                                                          _systemStatus(server, &_securitySettingsService),
+                                                                                          _coreDump(server, &_securitySettingsService)
 {
 }
 
@@ -147,6 +148,7 @@ void ESP32SvelteKit::begin()
     _wifiSettingsService.begin();
     _wifiScanner.begin();
     _wifiStatus.begin();
+    _coreDump.begin();
 
 #if FT_ENABLED(FT_UPLOAD_FIRMWARE)
     _uploadFirmwareService.begin();

--- a/lib/framework/ESP32SvelteKit.h
+++ b/lib/framework/ESP32SvelteKit.h
@@ -38,6 +38,7 @@
 #include <SecuritySettingsService.h>
 #include <SleepService.h>
 #include <SystemStatus.h>
+#include <CoreDump.h>
 #include <WiFiScanner.h>
 #include <WiFiSettingsService.h>
 #include <WiFiStatus.h>
@@ -241,6 +242,7 @@ private:
     RestartService _restartService;
     FactoryResetService _factoryResetService;
     SystemStatus _systemStatus;
+    CoreDump _coreDump;
 
     String _appName = APP_NAME;
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -76,6 +76,7 @@ extra_scripts =
     pre:scripts/generate_cert_bundle.py
     scripts/merge_bin.py
     scripts/rename_fw.py
+    scripts/save_elf.py
 lib_deps = 
 	ArduinoJson@>=7.0.0
     elims/PsychicMqttClient@^0.2.1

--- a/scripts/save_elf.py
+++ b/scripts/save_elf.py
@@ -1,0 +1,34 @@
+import shutil
+import re
+import os
+Import("env")
+import hashlib
+
+
+OUTPUT_DIR = "build{}elf{}".format(os.path.sep,os.path.sep)
+
+def elf_copy(source, target, env):
+    # check if output directories exist and create if necessary
+    if not os.path.isdir("build"):
+        os.mkdir("build")
+
+    if not os.path.isdir(OUTPUT_DIR):
+        os.mkdir(OUTPUT_DIR)
+
+    with open(str(target[0]),"rb") as f:
+        result = hashlib.sha256(f.read())
+        
+        # create string with location and file names based on variant
+        elf_file = "{}{}.elf".format(OUTPUT_DIR, result.hexdigest())
+
+        # check if new target files exist and remove if necessary
+        for f in [elf_file]:
+            if os.path.isfile(f):
+                os.remove(f)
+
+        print("Saving ELF file to "+elf_file)
+
+        # copy firmware.bin to firmware/<variant>.bin
+        shutil.copy(str(target[0]), elf_file)
+        
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.elf", [elf_copy])


### PR DESCRIPTION
Added a new endpoint, /rest/coreDump, which enables downloading the latest core dump from the CPU.
Also introduced a script, save_elf.py, that stores a copy of the ELF file using the SHA-256 hash of the build as the filename.

The core dump includes the same SHA-256 hash from the original build, which makes it easy to match the core dump to the correct ELF file. This allows decoding and analysis of the dump.