### PR TITLE
Fixing JSON representation of WifiSettings

### DIFF
--- a/lib/framework/WiFiSettingsService.h
+++ b/lib/framework/WiFiSettingsService.h
@@ -102,11 +102,11 @@ public:
             wifiNetwork["static_ip_config"] = wifi.staticIPConfig;
 
             // extended settings
-            JsonUtils::writeIP(root, "local_ip", wifi.localIP);
-            JsonUtils::writeIP(root, "gateway_ip", wifi.gatewayIP);
-            JsonUtils::writeIP(root, "subnet_mask", wifi.subnetMask);
-            JsonUtils::writeIP(root, "dns_ip_1", wifi.dnsIP1);
-            JsonUtils::writeIP(root, "dns_ip_2", wifi.dnsIP2);
+            JsonUtils::writeIP(wifiNetwork, "local_ip", wifi.localIP);
+            JsonUtils::writeIP(wifiNetwork, "gateway_ip", wifi.gatewayIP);
+            JsonUtils::writeIP(wifiNetwork, "subnet_mask", wifi.subnetMask);
+            JsonUtils::writeIP(wifiNetwork, "dns_ip_1", wifi.dnsIP1);
+            JsonUtils::writeIP(wifiNetwork, "dns_ip_2", wifi.dnsIP2);
         }
 
         ESP_LOGV(SVK_TAG, "WiFi Settings read");


### PR DESCRIPTION
Currently in `lib/framework/WiFiSettingsService.h` the `read()` method creates an invalid structured JSON representation of `WifiSettings`, what leads to inconsistent read/update operations, especially if you intend to use static IP configuration.

The issue is, that within the for loop, while iterating through the networks, the network's properties are written to the JSON *root* level instead of to the network's particular _array item_. As a consequence, the resulting JSON missmatches the expected structure by the front end and the network settings properties cannot be visualized correctly.
The same effect should apply to persisting the settings file to the flash FS.

_Independent from the bugfix:_
I find the WiFi Station settings dialog somewhat unintuitive when using multiple network configurations. I found it difficult to understand how the respective configuration is loaded into the fields at the bottom of the dialog and how the "Add/Update Network" and "Apply Settings" buttons work.
Therefore, I changed the layout slightly and implemented a separate edit dialog (modal), which I think simplifies usage.
If there's interest, I could create a PR for that as well.