### PR TITLE
Add missing page.ts for Core Dump page

### DIFF
--- a/interface/src/routes/system/coredump/+page.ts
+++ b/interface/src/routes/system/coredump/+page.ts
@@ -1,0 +1,5 @@
+import type { PageLoad } from './$types';
+
+export const load = (async () => {
+	return { title: 'Core Dump' };
+}) satisfies PageLoad;


### PR DESCRIPTION
Hello :)

This PR adds the page.ts file for the Core Dump page. It returns the correct page title for the menu to show the selected menu item properly.

Cheers!