### PR TITLE
Making System Metric's PSRAM chart creation conditional

### DIFF
--- a/interface/src/routes/system/metrics/SystemMetrics.svelte
+++ b/interface/src/routes/system/metrics/SystemMetrics.svelte
@@ -112,7 +112,7 @@
 						borderColor: daisyColor('--color-primary'),
 						backgroundColor: daisyColor('--color-primary', 50),
 						borderWidth: 2,
-						data: $analytics.free_psram,
+						data: $analytics.used_psram,
 						yAxisID: 'y'
 					}
 				]


### PR DESCRIPTION
Hello :)

Rendering and updating of the `psramChart` is conditional in `SystemMetrics.svelte` as it depends on whether PSRAM data is available. Unfortunately the creation of the chart is not protected by a condition and therefore leads to a JS error in `SystemMetrics.svelte:100` :

<img width="696" height="109" alt="image" src="https://github.com/user-attachments/assets/c864dd28-c639-407b-baab-446ad3695980" />


Furthermore I changed the metrics data reference from `$analytics.free_psram` to `$analytics.used_psram`, what I assume has been the original intention when labeling the dataset _Used_:

<img width="466" height="267" alt="image" src="https://github.com/user-attachments/assets/ef4bff00-a47d-4520-8977-dd2d3ac2a531" />

Kind regards!