### PR TITLE
Extensible healthcheck

### DIFF
--- a/lib/framework/ESP32SvelteKit.cpp
+++ b/lib/framework/ESP32SvelteKit.cpp
@@ -53,6 +53,7 @@ ESP32SvelteKit::ESP32SvelteKit(PsychicHttpServer *server, unsigned int numberEnd
 #endif
                                                                                           _restartService(server, &_securitySettingsService),
                                                                                           _factoryResetService(server, &ESPFS, &_securitySettingsService),
+                                                                                          _healthCheckService(server, &_securitySettingsService),
 #if FT_ENABLED(FT_COREDUMP)
                                                                                           _coreDump(server, &_securitySettingsService),
 #endif
@@ -145,6 +146,7 @@ void ESP32SvelteKit::begin()
     _apSettingsService.begin();
     _factoryResetService.begin();
     _featureService.begin();
+    _healthCheckService.begin();
     _restartService.begin();
     _systemStatus.begin();
     _wifiSettingsService.begin();

--- a/lib/framework/ESP32SvelteKit.h
+++ b/lib/framework/ESP32SvelteKit.h
@@ -39,6 +39,7 @@
 #include <SleepService.h>
 #include <SystemStatus.h>
 #include <CoreDump.h>
+#include <HealthCheckService.h>
 #include <WiFiScanner.h>
 #include <WiFiSettingsService.h>
 #include <WiFiStatus.h>
@@ -181,6 +182,11 @@ public:
         return &_restartService;
     }
 
+    HealthCheckService *getHealthCheckService()
+    {
+        return &_healthCheckService;
+    }
+
     void factoryReset()
     {
         _factoryResetService.factoryReset();
@@ -245,6 +251,7 @@ private:
 #endif
     RestartService _restartService;
     FactoryResetService _factoryResetService;
+    HealthCheckService _healthCheckService;
     SystemStatus _systemStatus;
 
     String _appName = APP_NAME;

--- a/lib/framework/HealthCheckService.cpp
+++ b/lib/framework/HealthCheckService.cpp
@@ -1,0 +1,101 @@
+/**
+ *   HealthCheckService - Extensible Health Check Endpoint
+ *
+ *   Provides a /rest/health endpoint with callback-based extensibility
+ *   for the ESP32 SvelteKit framework.
+ *
+ *   Copyright (C) 2025 hmbacher
+ *
+ *   All Rights Reserved. This software may be modified and distributed under
+ *   the terms of the LGPL v3 license. See the LICENSE file for details.
+ **/
+
+#include <HealthCheckService.h>
+#include <SecurityManager.h>
+
+// Initialize static member
+health_check_handler_id_t HealthCheckHandlerInfo::currentHandlerId = 0;
+
+HealthCheckService::HealthCheckService(PsychicHttpServer *server, SecurityManager *securityManager) : _server(server), _securityManager(securityManager)
+{
+}
+
+void HealthCheckService::begin()
+{
+    _server->on(HEALTH_CHECK_SERVICE_PATH,
+                HTTP_GET,
+                _securityManager->wrapRequest(std::bind(&HealthCheckService::healthCheck, this, std::placeholders::_1),
+                                              AuthenticationPredicates::NONE_REQUIRED));
+
+    ESP_LOGV(SVK_TAG, "Registered GET endpoint: %s", HEALTH_CHECK_SERVICE_PATH);
+}
+
+esp_err_t HealthCheckService::healthCheck(PsychicRequest *request)
+{
+    PsychicJsonResponse response = PsychicJsonResponse(request, false);
+    JsonObject root = response.getRoot();
+    
+    // Always add the base "up" status
+    root["up"] = true;
+    
+    // Call all registered health check handlers to contribute to the JSON
+    callHealthCheckHandlers(root);
+    
+    return response.send();
+}
+
+health_check_handler_id_t HealthCheckService::addHealthCheckCallback(HealthCheckCallback cb, bool allowRemove)
+{
+    if (!cb)
+    {
+        ESP_LOGW(SVK_TAG, "Cannot add health check callback 'null'");
+        return 0;
+    }
+
+    HealthCheckHandlerInfo_t handler(cb, allowRemove);
+    _healthCheckHandlers.push_back(handler);
+    return handler._id;
+}
+
+void HealthCheckService::removeHealthCheckCallback(health_check_handler_id_t id)
+{
+    if (id == 0)
+    {
+        ESP_LOGW(SVK_TAG, "Invalid health check handler ID '0' for removal");
+        return;
+    }
+
+    for (auto i = _healthCheckHandlers.begin(); i != _healthCheckHandlers.end();)
+    {
+        if ((*i)._allowRemove && (*i)._id == id)
+        {
+            i = _healthCheckHandlers.erase(i);
+        }
+        else
+        {
+            ++i;
+        }
+    }
+}
+
+void HealthCheckService::callHealthCheckHandlers(JsonObject &json)
+{
+    for (const auto &handler : _healthCheckHandlers)
+    {
+        if (handler._cb)
+        {
+            try
+            {
+                handler._cb(json);
+            }
+            catch (const std::exception &e)
+            {
+                ESP_LOGW(SVK_TAG, "Health check callback failed: %s", e.what());
+            }
+            catch (...)
+            {
+                ESP_LOGW(SVK_TAG, "Health check callback failed with unknown exception");
+            }
+        }
+    }
+}

--- a/lib/framework/HealthCheckService.h
+++ b/lib/framework/HealthCheckService.h
@@ -1,0 +1,94 @@
+#ifndef HealthCheckService_h
+#define HealthCheckService_h
+
+/**
+ *   HealthCheckService - Extensible Health Check Endpoint
+ *
+ *   Provides a /rest/health endpoint with callback-based extensibility
+ *   for the ESP32 SvelteKit framework.
+ *
+ *   Copyright (C) 2025 hmbacher
+ *
+ *   All Rights Reserved. This software may be modified and distributed under
+ *   the terms of the LGPL v3 license. See the LICENSE file for details.
+ **/
+
+#include <PsychicHttp.h>
+#include <SecurityManager.h>
+#include <ArduinoJson.h>
+#include <functional>
+#include <list>
+#include <exception>
+
+#define HEALTH_CHECK_SERVICE_PATH "/rest/health"
+
+/**
+ * HealthCheckService provides an extensible health check endpoint at /rest/health
+ * 
+ * Basic usage returns: {"up": true}
+ * 
+ * Extended usage example:
+ * 
+ *   // Register a health check callback that adds WiFi status
+ *   esp32SvelteKit.getHealthCheckService()->addHealthCheckCallback([](JsonObject &json) {
+ *       json["wifi"]["connected"] = WiFi.isConnected();
+ *       json["wifi"]["rssi"] = WiFi.RSSI();
+ *   });
+ * 
+ *   // Register a callback that adds memory info
+ *   esp32SvelteKit.getHealthCheckService()->addHealthCheckCallback([](JsonObject &json) {
+ *       json["memory"]["free"] = ESP.getFreeHeap();
+ *       json["memory"]["total"] = ESP.getHeapSize();
+ *   });
+ * 
+ * This would result in a response like:
+ * {
+ *   "up": true,
+ *   "wifi": {"connected": true, "rssi": -45},
+ *   "memory": {"free": 123456, "total": 327680}
+ * }
+ */
+
+typedef size_t health_check_handler_id_t;
+typedef std::function<void(JsonObject &json)> HealthCheckCallback;
+
+typedef struct HealthCheckHandlerInfo
+{
+    static health_check_handler_id_t currentHandlerId;
+    health_check_handler_id_t _id;
+    HealthCheckCallback _cb;
+    bool _allowRemove;
+    HealthCheckHandlerInfo(HealthCheckCallback cb, bool allowRemove) : _id(++currentHandlerId), _cb(cb), _allowRemove(allowRemove) {};
+} HealthCheckHandlerInfo_t;
+
+class HealthCheckService
+{
+public:
+    HealthCheckService(PsychicHttpServer *server, SecurityManager *securityManager);
+
+    void begin();
+
+    /**
+     * @brief Add a health check callback that contributes to the JSON response
+     * @param cb Callback function that receives a JsonObject reference to populate
+     * @param allowRemove Whether this callback can be removed later (default: true)
+     * @return Handler ID (>0) that can be used to remove the callback. Returns 0 if the callback is null.
+     */
+    health_check_handler_id_t addHealthCheckCallback(HealthCheckCallback cb, bool allowRemove = true);
+    
+    /**
+     * @brief Remove a health check callback by its handler ID
+     * @param id The handler ID returned by addHealthCheckCallback()
+     */
+    void removeHealthCheckCallback(health_check_handler_id_t id);
+
+private:
+    PsychicHttpServer *_server;
+    SecurityManager *_securityManager;
+    std::list<HealthCheckHandlerInfo_t> _healthCheckHandlers;
+    
+    esp_err_t healthCheck(PsychicRequest *request);
+    void callHealthCheckHandlers(JsonObject &json);
+};
+
+#endif // end HealthCheckService_h


### PR DESCRIPTION
Hi @theelims, this PR contains now contains:

**Add extensible health check endpoint**
Introduces a new `/rest/health` endpoint that enables monitoring of device state, health, and availability from external monitoring systems.

Key features:
- Default response: Returns `{ "up": true }` out of the box
- Extensible design: Supports custom callback functions to add dynamic health information per request
- Lightweight: Minimizes data transfer by allowing customizable content tailored to specific monitoring needs
- Flexible: Can be extended with application-specific health metrics without modifying core functionality