### PR TITLE
Bugfix: Socket communication isn't initialized after very first login

### DIFF
--- a/interface/src/routes/+layout.svelte
+++ b/interface/src/routes/+layout.svelte
@@ -138,7 +138,7 @@
 </svelte:head>
 
 {#if page.data.features.security && $user.bearer_token === ''}
-	<Login on:signIn={initSocket} />
+	<Login signIn={initSocket} />
 {:else}
 	<div class="drawer lg:drawer-open">
 		<input id="main-menu" type="checkbox" class="drawer-toggle" bind:checked={menuOpen} />


### PR DESCRIPTION
Hi @theelims! Here just a very small bugfix that addresses the problem that the socket communication isn't initialized after the very first login leading to e.g. the wifi status not being displayed correctly. After a refresh or with having a bearer token everything was fine. That's now fixed.